### PR TITLE
Fix missing space in IconNames

### DIFF
--- a/libs/core/icons.ts
+++ b/libs/core/icons.ts
@@ -421,7 +421,7 @@ namespace images {
                                         # # # . .
                                         . # # # #
                                         . # # # .
-                                        . .. . .`);
+                                        . . . . .`);
             case IconNames.House: return images.createImage(`
                                         . . # . .
                                         . # # # .


### PR DESCRIPTION
Okay so this is clearly not a real bug, but when I exported the existing IconNames to an own project and replaced the hashes and dots with zeros and ones I got an error with the Duck Icon. That happens due to a missing space in line 424 in icons.ts.